### PR TITLE
Add app list to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-<!-- Déploiement test 3 -->
+# HoliProject Intranet
+
+## Development Setup
+
+This project requires PHP 8.2 or higher. To get started:
+
+1. Install PHP and Composer.
+2. Run `composer install` to install dependencies.
+3. Copy `.env.example` to `.env` and run `php artisan key:generate`.
+4. Run the local server with `php artisan serve`.
+
+## Running Tests
+
+Execute the test suite with:
+
+```bash
+vendor/bin/phpunit
+```
+
+If PHP is missing in your environment, install it first or use a Docker setup such as Laravel Sail.

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,9 +7,18 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <div class="mb-4 text-gray-900">
                     {{ __("You're logged in!") }}
+                </div>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    @foreach($apps as $app)
+                        <a href="{{ route($app['route']) }}"
+                           class="block p-4 border rounded hover:bg-gray-50">
+                            {{ $app['name'] }}
+                        </a>
+                    @endforeach
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,13 @@ require __DIR__ . '/auth.php';
 Route::middleware(['auth'])->group(function () {
     // Dashboard (par défaut)
     Route::get('/dashboard', function () {
-        return view('dashboard');
+        $apps = [
+            ['name' => 'Intranet', 'route' => 'intranet'],
+            ['name' => 'Contact', 'route' => 'contact.create'],
+            ['name' => 'Mon Profil', 'route' => 'profile.edit'],
+        ];
+
+        return view('dashboard', compact('apps'));
     })->name('dashboard');
 
     // Page principale de l’intranet


### PR DESCRIPTION
## Summary
- list available apps in the dashboard view
- document how to set up the app and run tests

## Testing
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*