### PR TITLE
Add app list to dashboard

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -13,4 +13,8 @@ php composer-setup.php --quiet
 php -r "unlink('composer-setup.php');"
 sudo mv composer.phar /usr/local/bin/composer
 
+php -v
 composer --version
+
+# Install project dependencies
+composer install --no-interaction --prefer-dist

--- a/.codex/test.sh
+++ b/.codex/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+if ! command -v php >/dev/null; then
+  echo "PHP is not installed. Run .codex/setup.sh first." >&2
+  exit 1
+fi
+
+vendor/bin/phpunit "$@"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-<!-- Déploiement test 3 -->
+# HoliProject Intranet
+
+This project uses Laravel. The provided helper scripts make it easier to set up
+PHP and run the test suite in Codex environments.
+
+## Setup
+
+Run the setup script to install PHP, Composer and the project dependencies:
+
+```bash
+bash .codex/setup.sh
+```
+
+## Testing
+
+After setup, run the tests with:
+
+```bash
+bash .codex/test.sh
+```
+
+The test script checks that PHP is available and delegates to `vendor/bin/phpunit`.

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,9 +7,18 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <div class="mb-4 text-gray-900">
                     {{ __("You're logged in!") }}
+                </div>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                    @foreach($apps as $app)
+                        <a href="{{ route($app['route']) }}"
+                           class="block p-4 border rounded hover:bg-gray-50">
+                            {{ $app['name'] }}
+                        </a>
+                    @endforeach
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,13 @@ require __DIR__ . '/auth.php';
 Route::middleware(['auth'])->group(function () {
     // Dashboard (par défaut)
     Route::get('/dashboard', function () {
-        return view('dashboard');
+        $apps = [
+            ['name' => 'Intranet', 'route' => 'intranet'],
+            ['name' => 'Contact', 'route' => 'contact.create'],
+            ['name' => 'Mon Profil', 'route' => 'profile.edit'],
+        ];
+
+        return view('dashboard', compact('apps'));
     })->name('dashboard');
 
     // Page principale de l’intranet


### PR DESCRIPTION
## Summary
- list available apps in the dashboard view
- add test helper and improve setup script
- document setup and test steps

## Testing
- `bash .codex/test.sh` *(fails: `PHP is not installed. Run .codex/setup.sh first.`)*
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*
