### PR TITLE
Add Codex test script

### DIFF
--- a/.codex/test.sh
+++ b/.codex/test.sh
@@ -2,13 +2,8 @@
 set -e
 
 if ! command -v php >/dev/null; then
-rxq017-codex/afficher-toutes-les-applications-dans-le-tableau-de-bord
   echo "PHP is not installed. Run .codex/setup.sh first." >&2
   exit 1
-
-    echo "PHP is not installed. Please run .codex/setup.sh to install dependencies." >&2
-    exit 1
-main
 fi
 
 vendor/bin/phpunit "$@"

--- a/README.md
+++ b/README.md
@@ -1,44 +1,24 @@
-rxq017-codex/afficher-toutes-les-applications-dans-le-tableau-de-bord
 # HoliProject Intranet
 
-This project uses Laravel. The provided helper scripts make it easier to set up
-PHP and run the test suite in Codex environments.
+This project uses Laravel. The provided helper scripts make it easier to set up PHP and run the test suite in Codex environments.
 
 ## Setup
 
 Run the setup script to install PHP, Composer and the project dependencies:
 
-2vdq1h-codex/afficher-toutes-les-applications-dans-le-tableau-de-bord
-# Holiproject Intranet
-
-This project uses Laravel. To run the test suite you must install PHP and Composer.
-
-## Setup
-
-Run the provided setup script to install PHP, Composer and other dependencies:
-main
-
 ```bash
 bash .codex/setup.sh
 ```
 
-rxq017-codex/afficher-toutes-les-applications-dans-le-tableau-de-bord
 ## Testing
 
 After setup, run the tests with:
-
-After setup, you can run the tests with:
-main
 
 ```bash
 bash .codex/test.sh
 ```
 
-rxq017-codex/afficher-toutes-les-applications-dans-le-tableau-de-bord
 The test script checks that PHP is available and delegates to `vendor/bin/phpunit`.
-
-
-# HoliProject Intranet
 
 ## Development Setup
 
@@ -58,5 +38,3 @@ vendor/bin/phpunit
 ```
 
 If PHP is missing in your environment, install it first or use a Docker setup such as Laravel Sail.
-main
-main


### PR DESCRIPTION
## Summary
- add `.codex/test.sh` to validate PHP is installed before running PHPUnit
- clean up README and document how to run the tests

## Testing
- `bash .codex/test.sh` *(fails: PHP not installed)*