### PR TITLE
Fix setup.sh composer install

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -13,15 +13,9 @@ php composer-setup.php --quiet
 php -r "unlink('composer-setup.php');"
 sudo mv composer.phar /usr/local/bin/composer
 
-rxq017-codex/afficher-toutes-les-applications-dans-le-tableau-de-bord
-
-# Install PHP dependencies
-composer install --prefer-dist --no-interaction --no-progress
-
-# Display versions for debugging
-main
-php -v
-composer --version
-
 # Install project dependencies
 composer install --no-interaction --prefer-dist
+
+# Display versions for debugging
+php -v
+composer --version


### PR DESCRIPTION
## Summary
- simplify `.codex/setup.sh`
- remove stray line and unused function call

## Testing
- `bash .codex/test.sh` *(fails: PHP is not installed)*