### PR TITLE
Add setup helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Run the setup script to install PHP, Composer and all project dependencies:
 bash .codex/setup.sh
 ```
 
-Next, copy the example environment file and generate an application key:
+Next, run the helper script to create your `.env` file, generate the
+application key and apply the database migrations:
 
 ```bash
-cp .env.example .env
-php artisan key:generate
+bash scripts/setup.sh
 ```
 
-After copying, edit `.env` to add your database credentials and other
-secrets. This file should never be committed to version control.
+After the script completes, edit `.env` to add your database credentials
+and other secrets. This file should never be committed to version control.
 
 After the setup completes, execute the test suite:
 
@@ -37,9 +37,9 @@ If you prefer to manage your own environment:
 
 1. Install PHP and Composer.
 2. Run `composer install` to install dependencies.
-3. Copy `.env.example` to `.env` and run `php artisan key:generate`.
-   Provide your own credentials in the new `.env` file and keep it out
-   of version control.
+3. Execute `bash scripts/setup.sh` to create `.env`, generate the
+   application key and run the migrations. Provide your own credentials
+   in the new `.env` file and keep it out of version control.
 4. Start the application with `php artisan serve`.
 
 ## Running PHPUnit

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure environment file exists
+if [ ! -f .env ]; then
+  echo "Copying .env.example to .env" >&2
+  cp .env.example .env
+fi
+
+# Generate application key if missing
+if ! grep -q '^APP_KEY=' .env || [ -z "$(grep '^APP_KEY=' .env | cut -d '=' -f2)" ]; then
+  echo "Generating application key" >&2
+  php artisan key:generate --ansi
+fi
+
+# Run database migrations if possible
+if [ -n "$(grep '^DB_CONNECTION=' .env | cut -d '=' -f2)" ]; then
+  echo "Running database migrations" >&2
+  php artisan migrate --force
+fi


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to create `.env`, generate key and run migrations
- update README to document the new setup helper

## Testing
- `bash .codex/test.sh` *(fails: PHP is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d58234d30832492837293ead8a58d