### PR TITLE
Remove stray lines in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,8 @@
 # Example application configuration. Copy this file to `.env`
-hux0tn-codex/exclure-.env-de-git-et-ajouter-.env.example
 # then run `php artisan key:generate` to set `APP_KEY`.
 # Provide your own secret values after copying.
 
 # and provide your own secret values.
-main
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=


### PR DESCRIPTION
## Summary
- cleanup `.env.example` by removing leftover `hux0tn-codex/...` and `main` lines

## Testing
- `bash .codex/test.sh` *(fails: PHP is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683d6fed80648324ab8a7f1eff94cd37