### PR TITLE
Add intranet access test

### DIFF
--- a/tests/Feature/IntranetTest.php
+++ b/tests/Feature/IntranetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IntranetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_access_intranet_page(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/intranet');
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add a feature test for the intranet page

## Testing
- `vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_683d7331bc648324ad24952464e65dce