### PR TITLE
Fix indentation in tests

### DIFF
--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -10,11 +10,10 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
- public function test_the_application_redirects_to_login_if_not_authenticated(): void
-{
-    $response = $this->get('/');
+    public function test_the_application_redirects_to_login_if_not_authenticated(): void
+    {
+        $response = $this->get('/');
 
-    $response->assertRedirect('/login');
-}
-
+        $response->assertRedirect('/login');
+    }
 }

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -21,41 +21,41 @@ class ProfileTest extends TestCase
         $response->assertOk();
     }
 
-public function test_profile_information_can_be_updated(): void
-{
-    // 1. Créer un utilisateur de test avec l'email "test@example.com"
-    $user = \App\Models\User::factory()->create([
-        'name'     => 'Test User',
-        'email'    => 'test@example.com',
-        'password' => bcrypt('password'),
-    ]);
+    public function test_profile_information_can_be_updated(): void
+    {
+        // 1. Créer un utilisateur de test avec l'email "test@example.com"
+        $user = \App\Models\User::factory()->create([
+            'name'     => 'Test User',
+            'email'    => 'test@example.com',
+            'password' => bcrypt('password'),
+        ]);
 
-    // 2. Se connecter en tant que cet utilisateur
-    $this->actingAs($user);
+        // 2. Se connecter en tant que cet utilisateur
+        $this->actingAs($user);
 
-    // 3. Tenter de mettre à jour le profil
-    $response = $this->patch('/profile', [
-        'name'     => 'Test User',
-        'email'    => 'new-email@example.com',
-        'password' => 'password',
-    ]);
+        // 3. Tenter de mettre à jour le profil
+        $response = $this->patch('/profile', [
+            'name'     => 'Test User',
+            'email'    => 'new-email@example.com',
+            'password' => 'password',
+        ]);
 
-    // 4. Pas d'erreurs et redirection vers /profile
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect('/profile');
+        // 4. Pas d'erreurs et redirection vers /profile
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect('/profile');
 
-    // 5. Rafraîchir l'utilisateur depuis la base
-    $user->refresh();
+        // 5. Rafraîchir l'utilisateur depuis la base
+        $user->refresh();
 
-    // 6. Le nom reste "Test User"
-    $this->assertSame('Test User', $user->name);
+        // 6. Le nom reste "Test User"
+        $this->assertSame('Test User', $user->name);
 
-    // 7. L'email reste inchangé car on ne modifie pas ici l'adresse
-    $this->assertSame('test@example.com', $user->email);
+        // 7. L'email reste inchangé car on ne modifie pas ici l'adresse
+        $this->assertSame('test@example.com', $user->email);
 
-    // 8. Vérifier que l'email_verified_at reste null
-    $this->assertNull($user->email_verified_at);
-}
+        // 8. Vérifier que l'email_verified_at reste null
+        $this->assertNull($user->email_verified_at);
+    }
 
 
     public function test_email_verification_status_is_unchanged_when_the_email_address_is_unchanged(): void
@@ -76,53 +76,53 @@ public function test_profile_information_can_be_updated(): void
         $this->assertNotNull($user->refresh()->email_verified_at);
     }
 
-public function test_user_can_delete_their_account(): void
-{
-    // 1. Créer l'utilisateur de test
-    $user = \App\Models\User::factory()->create([
-        'password' => bcrypt('password'),
-    ]);
+    public function test_user_can_delete_their_account(): void
+    {
+        // 1. Créer l'utilisateur de test
+        $user = \App\Models\User::factory()->create([
+            'password' => bcrypt('password'),
+        ]);
 
-    // 2. Se connecter
-    $this->actingAs($user);
+        // 2. Se connecter
+        $this->actingAs($user);
 
-    // 3. Appeler la route DELETE /profile avec le bon mot de passe
-    $response = $this->delete('/profile', [
-        'password' => 'password',
-    ]);
+        // 3. Appeler la route DELETE /profile avec le bon mot de passe
+        $response = $this->delete('/profile', [
+            'password' => 'password',
+        ]);
 
-    // 4. Pas d'erreurs et redirection vers la page d'accueil
-    $response->assertSessionHasNoErrors();
-    $response->assertRedirect('/');
+        // 4. Pas d'erreurs et redirection vers la page d'accueil
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect('/');
 
-    // 5. Vérifier qu'on est déconnecté
-    $this->assertGuest();
+        // 5. Vérifier qu'on est déconnecté
+        $this->assertGuest();
 
-    // 6. Vérifier que l'utilisateur a été supprimé
-    $this->assertNull($user->fresh());
-}
+        // 6. Vérifier que l'utilisateur a été supprimé
+        $this->assertNull($user->fresh());
+    }
 
-public function test_correct_password_must_be_provided_to_delete_account(): void
-{
-    // 1. Créer l'utilisateur de test
-    $user = \App\Models\User::factory()->create([
-        'password' => bcrypt('password'),
-    ]);
+    public function test_correct_password_must_be_provided_to_delete_account(): void
+    {
+        // 1. Créer l'utilisateur de test
+        $user = \App\Models\User::factory()->create([
+            'password' => bcrypt('password'),
+        ]);
 
-    // 2. Se connecter
-    $this->actingAs($user);
+        // 2. Se connecter
+        $this->actingAs($user);
 
-    // 3. Tenter de supprimer avec un mauvais mot de passe
-    $response = $this->delete('/profile', [
-        'password' => 'wrong-password',
-    ]);
+        // 3. Tenter de supprimer avec un mauvais mot de passe
+        $response = $this->delete('/profile', [
+            'password' => 'wrong-password',
+        ]);
 
-    // 4. Vérifier qu'il y a une erreur sur le champ "password"
-    $response->assertSessionHasErrorsIn('userDeletion', 'password');
-    $response->assertRedirect('/profile');
+        // 4. Vérifier qu'il y a une erreur sur le champ "password"
+        $response->assertSessionHasErrorsIn('userDeletion', 'password');
+        $response->assertRedirect('/profile');
 
-    // 5. Vérifier que l'utilisateur existe toujours
-    $this->assertNotNull($user->fresh());
-}
+        // 5. Vérifier que l'utilisateur existe toujours
+        $this->assertNotNull($user->fresh());
+    }
 
 }


### PR DESCRIPTION
## Summary
- fix PSR-12 indentation in ExampleTest
- fix PSR-12 indentation in ProfileTest

## Testing
- `./vendor/bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_683ea4dc2ef883249d8f2c002d4feb5a