### PR TITLE
Update documentation for production debug setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ En production, copiez l'exemple de configuration :
 ```bash
 cp .env.example .env
 php artisan key:generate
+sed -i 's/^APP_DEBUG=.*/APP_DEBUG=false/' .env
 ```
 
-Renseignez les valeurs sensibles dans `.env` sur le serveur puis exécutez `php artisan migrate --force` et `npm run build` pour compiler les assets.
+Ce dernier remplacement désactive le mode de débogage en production. Renseignez ensuite les valeurs sensibles dans `.env` sur le serveur puis exécutez `php artisan migrate --force` et `npm run build` pour compiler les assets.
 
 ## Licence
 


### PR DESCRIPTION
## Summary
- disable APP_DEBUG for production in deployment instructions

## Testing
- `bash .codex/test.sh` *(fails: PHP is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_683ea88680888324b47cef6e32cc2c29