### PR TITLE
Fix Vite manifest error in app layout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,17 +11,13 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
-99l6fv-codex/remplacer-le-script-cdn-dans-app.blade.php
     {{-- Tailwind via CDN if assets are not compiled --}}
     @if (file_exists(public_path('build/manifest.json')) || file_exists(public_path('hot')))
+        {{-- Compiled assets via Vite --}}
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     @else
         <script src="https://cdn.tailwindcss.com" integrity="sha384-w8fXw5bAcRpC5Hcps225y7sY9qsK0kGugHgd6Nq35p3xNmPR9U1FVLtZLkYI7Di5yucs5cjox96D65V+1GPLRA==" crossorigin="anonymous"></script>
     @endif
-
-    {{-- Compiled assets via Vite --}}
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
-main
 </head>
 <body class="font-sans antialiased">
     <div class="min-h-screen bg-gray-100 flex">


### PR DESCRIPTION
## Summary
- clean up `app.blade.php`
- wrap Vite asset inclusion in the fallback check

## Testing
- `./vendor/bin/phpunit --version` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_683eabcc0e7883249ba0fb299a77a98a