### PR TITLE
Fix openai service indentation

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -35,8 +35,7 @@ return [
         ],
     ],
     'openai' => [
-    'api_key' => env('OPENAI_API_KEY'),
-],
-
+        'api_key' => env('OPENAI_API_KEY'),
+    ],
 
 ];


### PR DESCRIPTION
## Summary
- fix indentation for `openai` service in `config/services.php`

## Testing
- `php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683eef9216ec8324be36df7eb6b3fa0b